### PR TITLE
Hidde navigation fix

### DIFF
--- a/private/controllers/WebsiteController.php
+++ b/private/controllers/WebsiteController.php
@@ -39,4 +39,9 @@ class WebsiteController {
 		$template_engine = get_template_engine();
 		echo $template_engine->render('404', ['content' => $content]);
 	}
+
+	public function switchLanguage($language){
+		languageSwitch($language);
+		redirect($_SERVER['HTTP_REFERER']);
+	}
 }

--- a/private/includes/functions.php
+++ b/private/includes/functions.php
@@ -245,22 +245,30 @@ function uploadAllImages(){
 	return array($fileNames);
 }
 
-function languageSwitch() {
-	if(!isset($_SESSION['lang'])) {
-		$_SESSION['lang'] = "nl";
-	} else if(isset($_GET['lang']) && $_SESSION['lang'] != $_GET['lang'] && !empty($_GET['lang'])) {
-		if($_GET['lang'] == "nl") {
-			$_SESSION['lang'] = "nl";
-		} else if($_GET['lang'] == "en"){
-			$_SESSION['lang'] = "en";
-		}
+function currentLanguage(){
+	if(!isset($_SESSION['lang'])){
+		$_SESSION['lang'] = 'nl';
 	}
+
+	return $_SESSION['lang'];
+}
+
+function languageSwitch($code) {
+
+	$languages = ['nl', 'en'];
+	
+	if(!in_array($code, $languages)){
+		$code = 'nl';
+	}
+
+	$_SESSION['lang'] = $code;
+	
 }
 
 function getContentCurrentLang($place, $content) {
 	foreach($content as $row) {
 		if($place === $row['name']) {
-			echo $row['content_' . $_SESSION['lang']];
+			echo $row['content_' . currentLanguage()];
 		}
 	} 
 }

--- a/private/routes.php
+++ b/private/routes.php
@@ -3,8 +3,6 @@
 use Pecee\Http\Request;
 use Pecee\SimpleRouter\Exceptions\NotFoundHttpException;
 use Pecee\SimpleRouter\SimpleRouter;
-use Website\Controllers\AdminController;
-use Website\Controllers\WebsiteController;
 
 SimpleRouter::setDefaultNamespace( 'Website\Controllers' );
 

--- a/private/routes.php
+++ b/private/routes.php
@@ -4,6 +4,7 @@ use Pecee\Http\Request;
 use Pecee\SimpleRouter\Exceptions\NotFoundHttpException;
 use Pecee\SimpleRouter\SimpleRouter;
 use Website\Controllers\AdminController;
+use Website\Controllers\WebsiteController;
 
 SimpleRouter::setDefaultNamespace( 'Website\Controllers' );
 
@@ -11,6 +12,7 @@ SimpleRouter::group( [ 'prefix' => site_url() ], function () {
 
 	SimpleRouter::get( '/', 'WebsiteController@home' )->name( 'home' );
 	SimpleRouter::get( '/over-mij', 'WebsiteController@about' )->name( 'over' );
+	SimpleRouter::get('/switch-language/{language}', 'WebsiteController@switchLanguage')->name('switch-lang');
 
 	// Contact Routes
 	SimpleRouter::get( '/contact', 'ContactController@contact' )->name( 'contact' );

--- a/private/views/_navigation.php
+++ b/private/views/_navigation.php
@@ -26,8 +26,8 @@
             <!-- </li> -->
 
             <li class="menu-item taal-switch">
-                <a class="nl" href="?lang=nl" <?php if($_SESSION['lang'] == 'nl') : ?> style="font-weight: bold;" <?php endif; ?>>NL</a> | 
-                <a class="en" href="?lang=en" <?php if($_SESSION['lang'] == 'en') : ?> style="font-weight: bold;" <?php endif; ?>>EN</a>
+                <a class="nl" href="<?php echo url('switch-language', ['language' => 'nl'])?>" <?php if(currentLanguage() == 'nl'): ?> style="font-weight: bold;" <?php endif; ?>>NL</a> | 
+                <a class="en" href="<?php echo url('switch-language', ['language' => 'en'])?>" <?php if(currentLanguage() == 'en'): ?> style="font-weight: bold;" <?php endif; ?>>EN</a>
             </li>
 
             <li class="menu-items menu-item contactNav">

--- a/public/index.php
+++ b/public/index.php
@@ -15,8 +15,6 @@ require_once get_config('PRIVATE') . '/models/model.php';
 // Alle routes (URL's) in een apart bestand
 require_once get_config('PRIVATE') . '/routes.php';
 
-languageSwitch();
-
 /**
  * Hier wordt de opgevraagde URL gematched aan alle URL's die zijn ingesteld
  * Als de URL bestaat wordt de juiste code aangeroepen die er bij hoort (de controller)


### PR DESCRIPTION
Ha Mees.

Ik heb een nieuwe route gemaakt, en jouw taalswitch dus in een controller gezet en niet in de algemene frontcontroller.
Deze nieuwe route: `/switch-language/{language}` switcht de taal en redirect meteen weer terug naar de pagina waar je vandaan komt.

Verder heb ik nog de `languageSwitch()` functie iets aangepast zodat deze de taalcode doorkrijgt
En ik heb een function toegevoegd waarmee je de huidige taal kunt opvragen: `currentLanguage()`. Het is niet zo lekker om de $_SESSION overal direct aan te spreken. Handiger om dat op 1 plek op te vragen en op te slaan (want misschien wil je het later niet in de sessie maar op een andere manier opslaan. Dan hoef je dat maar op 1 plek te doen.
